### PR TITLE
install script for windows

### DIFF
--- a/make_package.bat
+++ b/make_package.bat
@@ -1,0 +1,35 @@
+@rem npmパッケージインストール
+cmd /c npm install
+
+@rem パッケージ用ディレクトリ用意
+if not exist package (
+  mkdir package
+)
+del package /Q
+if not exist package\web (
+  mkdir package\web
+)
+del package\web /Q
+
+@rem ビルド
+cd scala
+cmd /c sbt fullOptJS
+cd ..
+cd web
+cmd /c npm install
+cmd /c npm run build
+cd ..
+
+@rem コピー
+copy package.json package
+copy main.js package
+copy yarn.lock package
+xcopy assets package\assets /E /I /Y
+xcopy web\build package\web\build /E /I /Y
+xcopy node_modules package\node_modules /E /I /Y
+
+@rem パッケージ
+cd package
+cmd /c yarn install
+cmd /c npm run package
+cd ..

--- a/web/package.json
+++ b/web/package.json
@@ -4,9 +4,9 @@
   "author": "Shinpei Maruyama",
   "license": "MIT",
   "scripts": {
-    "build": "npm run clean && cp src/index.html build/index.html && webpack",
-    "watch": "npm run clean && cp src/index.html build/index.html && webpack -w",
-    "clean": "rm -rf build/*"
+    "build": "npm run clean && cpx src/index.html build && webpack",
+    "watch": "npm run clean && cpx src/index.html build && webpack -w",
+    "clean": "rimraf build/*"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -15,7 +15,9 @@
     "css-loader": "^0.28.7",
     "vue-loader": "^13.0.4",
     "vue-template-compiler": "^2.4.2",
-    "webpack": "^3.5.6"
+    "webpack": "^3.5.6",
+    "rimraf": "^2.6.1",
+    "cpx": "^1.5.0"
   },
   "dependencies": {
     "vue": "^2.4.2",


### PR DESCRIPTION
make_package.bat
---

`make_package.sh`をもとにcmd.exeのコマンドに置き換える。

web/package.json
---

`sh`のコマンドに依存していたため、同党のことを行う以下のnpmパッケージを
導入して置き換える。

- rimraf
- cpx

また、ルートフォルダー、webフォルダーにて`npm install`が必要だったような
ので、こちらも追加する。

パッケージ作成スクリプト実行結果
---
https://gist.github.com/masaru-b-cl/d98eb4ea30db124deeac8f0ceb4b2a8a